### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "nodejs"
+run = "echo hello word"

--- a/README.md
+++ b/README.md
@@ -1481,6 +1481,8 @@ If you want to include math inside of a presentation written in Markdown you nee
 `$$ J(\theta_0,\theta_1) = \sum_{i=0} $$`
 ```
 
+[![Run on Repl.it](https://repl.it/badge/github/Nels2/reveal.js)](https://repl.it/github/Nels2/reveal.js) 
+
 ## License
 
 MIT licensed


### PR DESCRIPTION
This pull request configures this repository to be run on Repl.it.      It adds a `.replit` configuration file and a Repl.it badge to the `README`.
     You can read more about running repos on Repl.it [here](https://docs.repl.it/repls/dot-replit), or view the Repl [here](https://repl.it/@nels277/revealjs).